### PR TITLE
AM-2747 temp disable SecurityScan in Nightly build

### DIFF
--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -88,7 +88,8 @@ withNightlyPipeline(type, product, component) {
   overrideVaultEnvironments(vaultOverrides)
   loadVaultSecrets(secrets)
 
-  enableSecurityScan()
+  // temp disable for AM-2742 / AM-2747
+  // enableSecurityScan()
   enableFullFunctionalTest()
   enableFortifyScan()
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

   [AM-2747](https://tools.hmcts.net/jira/browse/AM-2747) _"Temp disable SecurityScan step in Jenkins Nightly config to avoid errors from DTSPO-7198"_
   [DTSPO-7198](https://tools.hmcts.net/jira/browse/DTSPO-7198) _"Move security.sh to Jenkins library rather than all repositories"_

### Change description ###

Temp disable SecurityScan step in Jenkins Nightly config to avoid errors from DTSPO-7198.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
