### PR TITLE
AM-2742 add SecurityRules config to Jenkins_CNP

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -5,7 +5,12 @@ properties(
       $class       : 'GithubProjectProperty',
       projectUrlStr: 'https://github.com/hmcts/am-judicial-booking-service'
     ],
-    pipelineTriggers([[$class: 'GitHubPushTrigger']])
+    pipelineTriggers([[$class: 'GitHubPushTrigger']]),
+    parameters([
+      string(name: 'SecurityRules',
+            defaultValue: 'http://raw.githubusercontent.com/hmcts/security-test-rules/master/conf/security-rules.conf',
+            description: 'The URL you want to run these tests against'),
+    ])
   ]
 )
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

   [AM-2742](https://tools.hmcts.net/jira/browse/AM-2742) _"Update Jenkins Nightly config to comply with changes introduced by DTSPO-7198"_
   [DTSPO-7198](https://tools.hmcts.net/jira/browse/DTSPO-7198) _"Move security.sh to Jenkins library rather than all repositories"_

### Change description ###

Add SecurityRules config to Jenkins to allow test of SecurityScan step: i.e. to test #714. 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
