### PR TITLE
AM-2782 CVE-2021-22044 spring-cloud-starter-openfeign upgraded to 2.2…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -354,7 +354,7 @@ dependencies {
     implementation group: 'org.springframework.boot', name: 'spring-boot-starter-oauth2-resource-server'
     implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-bootstrap', version: '3.1.6'
     implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-netflix-hystrix', version: '2.2.10.RELEASE'
-    implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-openfeign', version: '2.2.7.RELEASE'
+    implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-openfeign', version: '2.2.10.RELEASE'
     implementation group: 'org.springframework.retry', name: 'spring-retry', version: '2.0.1'
     implementation group: 'org.springframework.security', name: 'spring-security-core', version: '6.0.2'
     implementation group: 'org.springframework.security', name: 'spring-security-web'

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -6,10 +6,6 @@
         <cve>CVE-2022-1471</cve>
     </suppress>
     <suppress>
-      <notes></notes>
-      <cve>CVE-2021-22044</cve>
-    </suppress>
-    <suppress>
         <notes>https://tools.hmcts.net/jira/browse/AM-2776 springframework</notes>
         <cve>CVE-2023-20863</cve>
     </suppress>


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/AM-2782
CVE-2021-22044 spring-cloud-starter-openfeign upgraded to 2.2.10.RELEASE

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
