### PR TITLE
AM-2878 Checkstyle report missing when build fails - gradle plugin uk…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ buildscript {
 
 plugins {
     id 'application'
-    id 'uk.gov.hmcts.java' version '0.12.12'
+    id 'uk.gov.hmcts.java' version '0.12.43'
     id 'pmd'
     id 'jacoco'
     id 'io.spring.dependency-management' version '1.1.0'


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/AM-2878
Checkstyle report missing when build fails - gradle plugin uk.gov.hmcts.java 0.12.43 with checkstyle errors to test is report create

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
