### PR TITLE
DTSAM-322 Decommission custom Postgres-V15 key vault values now that …

### DIFF
--- a/charts/am-judicial-booking-service/Chart.yaml
+++ b/charts/am-judicial-booking-service/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.0"
 description: A Helm chart for AM Judicial Booking Service
 name: am-judicial-booking-service
 home: https://github.com/hmcts/am-judicial-booking-service
-version: 0.0.60
+version: 0.0.61
 maintainers:
   - name: Access Management Team
 dependencies:

--- a/charts/am-judicial-booking-service/values.yaml
+++ b/charts/am-judicial-booking-service/values.yaml
@@ -10,11 +10,11 @@ java:
       secrets:
         - name: am-judicial-booking-service-s2s-secret
           alias: AM_JUDICIAL_BOOKING_SERVICE_SECRET
-        - name: judicial-booking-service-POSTGRES-PASS-V15
+        - name: judicial-booking-service-POSTGRES-PASS
           alias: JUDICIAL_BOOKING_SERVICE_POSTGRES_PASS
-        - name: judicial-booking-service-POSTGRES-USER-V15
+        - name: judicial-booking-service-POSTGRES-USER
           alias: JUDICIAL_BOOKING_SERVICE_POSTGRES_USER
-        - name: judicial-booking-service-POSTGRES-HOST-V15
+        - name: judicial-booking-service-POSTGRES-HOST
           alias: JUDICIAL_BOOKING_SERVICE_POSTGRES_HOST
         - name: app-insights-connection-string
           alias: app-insights-connection-string


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DTSAM-321
Decommission custom Postgres-V15 key vault values now that the standard ones are pointing to V15 instance

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] Does this PR introduce a breaking change
