### PR TITLE
DTSAM-321 Decommission custom Postgres-V15 key vault values now that …

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -116,21 +116,3 @@ module "judicial-booking-database-v15" {
     }
   ]
 }
-
-resource "azurerm_key_vault_secret" "POSTGRES-PASS-V15" {
-  name          = "${var.component}-POSTGRES-PASS-V15"
-  value         = module.judicial-booking-database-v15.password
-  key_vault_id  = data.azurerm_key_vault.am_key_vault.id
-}
-
-resource "azurerm_key_vault_secret" "POSTGRES-USER-V15" {
-  name         = "${var.component}-POSTGRES-USER-V15"
-  value        = module.judicial-booking-database-v15.username
-  key_vault_id  = data.azurerm_key_vault.am_key_vault.id
-}
-
-resource "azurerm_key_vault_secret" "POSTGRES-HOST-V15" {
-  name         = "${var.component}-POSTGRES-HOST-V15"
-  value        = module.judicial-booking-database-v15.fqdn
-  key_vault_id  = data.azurerm_key_vault.am_key_vault.id
-}


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DTSAM-321
Decommission custom Postgres-V15 key vault values now that the standard ones are pointing to V15 instance

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] Does this PR introduce a breaking change
