### PR TITLE
DTSAM-379 canIDeploy Index 0 out of bounds for length 0 Issue - comma…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -154,11 +154,8 @@ idea {
 
 project.ext {
     pacticipant = 'accessMgmt_judicialBooking'
-    pacticipantVersion = getCheckedOutGitCommitHash()
-}
-
-static def getCheckedOutGitCommitHash() {
-    'git rev-parse --verify --short HEAD'.execute().text.trim()
+    // DTSAM-379 canIDeploy Index 0 out of bounds for length 0 Issue
+    pacticipantVersion = System.env.GIT_COMMIT.substring(0,9)
 }
 
 tasks.withType(JavaCompile) {


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DTSAM-379
canIDeploy Index 0 out of bounds for length 0 Issue - command line git to get commit hash replaced with system env var substring

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] Does this PR introduce a breaking change
