### PR TITLE
DTSAM-1107 temp update to Jenkinsfile_nightly

### DIFF
--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -12,7 +12,7 @@ properties([
   ])
 ])
 
-@Library("Infrastructure")
+@Library("Infrastructure@docker-wait")
 
 def type = "java"
 def product = "am"


### PR DESCRIPTION
### Jira link

[DTSAM-1107](https://tools.hmcts.net/jira/browse/DTSAM-1107) _"Pipeline failures due to docker"_

### Change description

There are ongoning pipeline failures generating errors due to docker test containers, see [DTSPO-28646](https://tools.hmcts.net/jira/browse/DTSPO-28646).

PlatOps have asked us to test against their docker-wait branch.