### PR TITLE
DTSAM-1107 Revert temp update to Jenkinsfile_nightly

### DIFF
--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -12,7 +12,7 @@ properties([
   ])
 ])
 
-@Library("Infrastructure@docker-wait")
+@Library("Infrastructure")
 
 def type = "java"
 def product = "am"


### PR DESCRIPTION
### Jira link

[DTSAM-1107](https://tools.hmcts.net/jira/browse/DTSAM-1107) _"Pipeline failures due to docker"_

### Change description

This is a revert of the temp update to Jenkinsfile_nightly file made in #1376. 